### PR TITLE
Run `prefetch_crt_dependency.sh` and install files into package.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,3 +6,4 @@ jobs:
     with:
       source: git+https://github.com/aws/aws-sdk-cpp.git
       debian_source: native
+      build_options: nocheck

--- a/debian/rules
+++ b/debian/rules
@@ -7,8 +7,10 @@ source:
 	dh $@
 
 override_dh_auto_configure:
+	sh prefetch_crt_dependency.sh
 	dh_auto_configure -- \
 		-DCMAKE_BUILD_TYPE=Release \
 		-DBUILD_SHARED_LIBS=OFF \
-		-DLEGACY_BUILD=OFF \
+		-DCMAKE_INSTALL_LIBDIR=/usr/lib \
+		-DCMAKE_INSTALL_INCLUDEDIR=/usr/include \
 		-DBUILD_ONLY="kms;acm-pca"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR ensures that the package contains proper files after build by enabling the legacy mode. In addition some external dependency must be fetch otherwise the build fails and also some checks had to be disabled.

**Which issue(s) this PR fixes**:
Fixes #1 
