### PR TITLE
Remove dedicated fetch task

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -7,10 +7,7 @@ source:
 	dh $@
 
 override_dh_auto_configure:
-	sh prefetch_crt_dependency.sh
 	dh_auto_configure -- \
 		-DCMAKE_BUILD_TYPE=Release \
 		-DBUILD_SHARED_LIBS=OFF \
-		-DCMAKE_INSTALL_LIBDIR=/usr/lib \
-		-DCMAKE_INSTALL_INCLUDEDIR=/usr/include \
 		-DBUILD_ONLY="kms;acm-pca"


### PR DESCRIPTION
**What this PR does / why we need it**:
The pipeline has been adjusted so it is not necessary for the package itself to get all its required files anymore (while using git as source type).

**Which issue(s) this PR fixes**:
Fixes #3 

